### PR TITLE
Fix a bug for checking numpy version and two typos.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -132,8 +132,9 @@ Eg
 __version__ = '1.1'
 
 import os
+from distutils.version import LooseVersion
 import numpy
-if numpy.__version__ <= '1.8.0':
+if LooseVersion(numpy.__version__) <= LooseVersion('1.8.0'):
     raise SystemError("You're using an old version of Numpy (%s). "
                       "It is recommended to upgrad numpy to 1.8.0 or newer. \n"
                       "You still can use all features of PySCF with the old numpy by removing this warning msg. "

--- a/examples/gto/00-input_mole.py
+++ b/examples/gto/00-input_mole.py
@@ -128,7 +128,7 @@ mol.basis = '6-31g'
 # environment, it can simply be achieved, e.g.
 mol.basis = dict([(a, 'sto-3g') for a in pyscf.lib.parameters.NUC.keys()])
 mol.basis['C'] = '6-31g'
-# where pyscf.lib.parameters.NUC.keys() returns all atomci symbols.
+# where pyscf.lib.parameters.NUC.keys() returns all atomic symbols.
 # However, the functions basis.load and basis.parse are defined for other good
 # reason.  Since the basis-name input method only assigns the basis set
 # according to the associated atomic symbol,  basis.load and basis.parse can

--- a/scf/hf.py
+++ b/scf/hf.py
@@ -436,7 +436,7 @@ def damping(s, d, f, factor):
 
 # full density matrix for RHF
 def make_rdm1(mo_coeff, mo_occ):
-    '''One-particle densit matrix
+    '''One-particle density matrix
 
     Args:
         mo_coeff : 2D ndarray


### PR DESCRIPTION
I found a bug for comparing numpy version string. String comparison is based on "alphabetical order" rules applied to digits.