### PR TITLE
Add codes, test and example for mom-DeltaSCF. And fix some typos.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -114,7 +114,7 @@ For most methods, there are three stream functions to pipe computing stream:
 ``mf = scf.RHF(mol).set(conv_tol=1e-5)`` is identical to proceed in two steps
 ``mf = scf.RHF(mol); mf.conv_tol=1e-5``
 
-2 ``.run`` function to execute the kenerl function (the function arguments
+2 ``.run`` function to execute the kernel function (the function arguments
 are passed to kernel function).  If keyword arguments is given, it will first
 call ``.set`` function to update object attributes then execute the kernel
 function.  Eg

--- a/examples/dft/31-xc_value_on_grid.py
+++ b/examples/dft/31-xc_value_on_grid.py
@@ -5,7 +5,7 @@ from pyscf import gto, dft
 from pyscf.dft import numint
 
 '''
-Evaluate exchange-correlation functional and itr potential on given grid
+Evaluate exchange-correlation functional and its potential on given grid
 coordinates.
 '''
 

--- a/examples/scf/50-mom-deltaSCF.py
+++ b/examples/scf/50-mom-deltaSCF.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# Author: Junzi Liu <latrix1247@gmail.com>
+
+from pyscf import gto, scf, dft
+
+'''
+ Delta-SCF with maximium occupation method for calculating specific excited state.
+
+ Here two SCF procedures are carried out with different MO occupation principle.
+ Firstly the energy and molecular orbital information of ground state is
+ obtained by a regular SCF calculation. The excited state is calculated by an
+ independent SCF with a prescribed occupation pattern based on ground state. The
+ energy difference between this two states can be seen as the excitation erergy
+ originated from previous assigned orbitals.
+
+ Instead of Afubau principle, maximium occupation method is used to avoid the
+ excited state collpsing to ground state. Original get_occ will be replace by
+ mom_occ with an addon and you will see message as below:
+
+ overwite keys get_occ of <class 'pyscf.scf.uks.UKS'>
+'''
+
+mol = gto.Mole()
+mol.verbose = 1
+#mol.output ='mom_DeltaSCF.out'
+mol.atom = [
+    ["O" , (0. , 0.     , 0.)],
+    ["H" , (0. , -0.757 , 0.587)],
+    ["H" , (0. , 0.757  , 0.587)] ]
+mol.basis = {"H": '6-31g',
+             "O": '6-31g',}
+mol.build()
+
+a = dft.UKS(mol)
+a.xc = 'b3lyp'
+# Use chkfile to store ground state information and start excited state
+# caculation from these information directly 
+#mf.chkfile='ground.chkfile'
+a.scf()
+
+# Read MO coefficients and occpuation number from chkfile
+#mo0 = scf.chkfile.load('ground.chkfile', 'scf/mo_coeff')
+#occ = scf.chkfile.load('ground.chkfile', 'scf/mo_occ')
+mo0 = a.mo_coeff
+occ = a.mo_occ
+
+# Assigned initial occupation pattern
+occ[0][4]=0      # this excited state is originated from HOMO(alpha) -> LUMO(alpha)
+occ[0][5]=1      # it is still a singlet state
+
+# New SCF caculation 
+b = dft.UKS(mol)
+b.xc = 'b3lyp'
+
+# construct new dnesity matrix with new occpuation pattern
+dm = b.make_rdm1(mo0, occ)
+# Use mom occupation principle overwirte original one
+b.get_occ = scf.addons.mom_occ(b, mo0, occ)
+# Start new SCF with new density matrix
+b.scf(dm)
+
+print('Excited state energy: %.3g eV' % ((b.e_tot - a.e_tot)*27.211))
+print('Alpha electron occpation pattern of excited state : %s' %(b.mo_occ[0]))
+print(' Beta electron occpation pattern of excited state : %s' %(b.mo_occ[1]))

--- a/scf/test/test_addons.py
+++ b/scf/test/test_addons.py
@@ -4,7 +4,7 @@ import unittest
 import numpy
 import scipy.linalg
 from pyscf import gto
-from pyscf import scf
+from pyscf import scf, dft
 
 mol = gto.Mole()
 mol.verbose = 0
@@ -127,6 +127,18 @@ class KnowValues(unittest.TestCase):
         mf.get_occ = scf.addons.float_occ(mf)
         self.assertAlmostEqual(mf.scf(), -37.590712883365917, 9)
 
+    def test_mom_occ(self):
+        mf = dft.UKS(mol)
+        mf.xc = 'b3lyp'
+        mf.scf()
+        mo0 = mf.mo_coeff
+        occ = mf.mo_occ
+        occ[0][4] = 0.
+        occ[0][5] = 1.
+        mf.get_occ = scf.addons.mom_occ(mf, mo0, occ)
+        dm = mf.make_rdm1(mo0, occ)
+        self.assertAlmostEqual(mf.scf(dm), -76.0606858736708, 9)
+        self.assertTrue(numpy.allclose(mf.mo_occ[0][:6], [1,1,1,1,0,1]))
 
 if __name__ == "__main__":
     print("Full Tests for addons")

--- a/scf/uhf.py
+++ b/scf/uhf.py
@@ -68,7 +68,7 @@ def get_init_guess(mol, key='minao'):
         return init_guess_by_minao(mol)
 
 def make_rdm1(mo_coeff, mo_occ):
-    '''One-particle densit matrix
+    '''One-particle density matrix
 
     Returns:
         A list of 2D ndarrays for alpha and beta spins


### PR DESCRIPTION
Write an addon to overwrite _get_occ_ attribution for realizing mom-DeltaSCF calculation. It is similar to follow_state addon, but it is based on unrestricted HF/DFT.  Don't consider the symmetry so far.  