### PR TITLE
A dependence problem for compiling libxc_itrf.so

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -64,7 +64,7 @@ include(ExternalProject)
   )
 #endif()
 include_directories(${PROJECT_SOURCE_DIR}/deps/include)
-link_directories(${PROJECT_SOURCE_DIR}/deps/lib)
+link_directories(${PROJECT_SOURCE_DIR}/deps/lib ${PROJECT_SOURCE_DIR}/deps/lib64)
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/config.h.in"


### PR DESCRIPTION
Compiling libxc_itrf.so need the dependence of libxc.so which is in  deps/lib64. However, in CMakeLists.txt, the link_directories is set as :

 link_directories(${PROJECT_SOURCE_DIR}/deps/lib)

So  the link.txt in xc_itrf.dir has not correct link path. It can not find -lxc.

I added the deps/lib64 path in link_directories. But I feel it is ugly. It should have  an elegant solution?  I am not sure, maybe find_library() or target_link_libraries().  

Thank you :)