### PR TITLE
A couple fixes for UHF with k-points.

### DIFF
--- a/pbc/scf/kuhf.py
+++ b/pbc/scf/kuhf.py
@@ -20,6 +20,7 @@ from pyscf.pbc.scf import khf
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.pbc.scf import addons
+import pyscf
 
 
 def make_rdm1(mo_coeff_kpts, mo_occ_kpts):

--- a/scf/uhf.py
+++ b/scf/uhf.py
@@ -738,8 +738,14 @@ class UHF(hf.SCF):
     @lib.with_doc(spin_square.__doc__)
     def spin_square(self, mo_coeff=None, s=None):
         if mo_coeff is None:
+            #print(self.mo_coeff.shape)
             mo_coeff = (self.mo_coeff[0][:,self.mo_occ[0]>0],
                         self.mo_coeff[1][:,self.mo_occ[1]>0])
+            if len(self.mo_coeff.shape)==4:
+              #For k-points, let's just print out the gamma point.
+              mo_coeff = (self.mo_coeff[0,0][:,self.mo_occ[0,0]>0],
+                          self.mo_coeff[1,0][:,self.mo_occ[1,0]>0])
+
         if s is None:
             s = self.get_ovlp()
         return spin_square(mo_coeff, s)
@@ -763,9 +769,9 @@ class UHF(hf.SCF):
         return dip_moment(mol, dm, unit_symbol, verbose=verbose)
 
     def _finalize(self):
-        ss, s = self.spin_square((self.mo_coeff[0][:,self.mo_occ[0]>0],
-                                  self.mo_coeff[1][:,self.mo_occ[1]>0]),
-                                 self.get_ovlp())
+        ss, s = self.spin_square()
+                                  
+                                 
         if self.converged:
             logger.note(self, 'converged SCF energy = %.15g  '
                         '<S^2> = %.8g  2S+1 = %.8g', self.e_tot, ss, s)


### PR DESCRIPTION
Hi all,

I found a couple problems in kuhf:
1) import pyscf was missing which caused problems for me.
2) spin_square was not handling the case where mo_coeff had 4 indices correctly. I made a fix; we only compute spin_square on the gamma point. I don't know if that's the best solution. 

Here is a file that shows the problem.

import sys
import pyscf
import numpy
from pyscf.pbc import gto,scf
from pyscf.pbc.scf import KRHF as RHF
from pyscf.pbc.scf import KUHF as UHF
from pyscf.pbc.dft import KRKS as RKS
from pyscf.pbc.dft import KUKS as UKS
#from pyscf2qwalk import print_qwalk
basis={
'Si':pyscf.gto.basis.parse('''
Si s
  0.282668 0.464290 
  0.614115 -0.002322 
  1.334205 -0.268234 
  2.898645 0.031921 
  6.297493 -0.000106 
  13.681707 -0.000145 
  29.724387 0.000067 
 Si s
  0.507467 1.000000 
 Si p
  0.158712 0.417773 
  0.330843 0.281676 
  0.689658 0.069876 
  1.437625 -0.056306 
  2.996797 0.000744 
  6.246966 -0.000259 
  13.022097 -0.000022 
 Si d
  0.170395 1.000000 
 Si d
  0.539756 1.000000 
 Si f
  0.352999 1.000000 
 Si s
0.2 1.0
 Si s
0.4 1.0
 Si p
0.2 1.0
 Si p
0.4 1.0
'''),
}
mol=gto.M(verbose=4,
gs=[4, 4, 4],
atom='''Si -4.0728975000000025 -4.072897500000001 -4.0728975
Si 0.0 0.0 0.0
''',
a=''' -2.7152650000000005 -2.715265 0.0 -2.715265 0.0 -2.715265 -4.440892098500626e-16 -2.715265 -2.715265 ''',
basis=basis,
ecp='bfd')
mol.charge=0
mol.spin=0
kpts=mol.make_kpts([3, 3, 3])
m=UKS(mol,kpts)
m.max_cycle=50
m.direct_scf_tol=1e-07
m.chkfile='pyscfdriver.py.chkfile'
m.conv_tol=1e-07
m.diis_start_cycle=1
init_dm=pyscf.scf.uhf.init_guess_by_minao(mol)
dm_kpts= numpy.array([[init_dm[0] for k in range(len(kpts))],[init_dm[1] for k in range(len(kpts))]])
m.xc="pbe,pbe"
print('E(HF) =',m.kernel(dm_kpts))
#print_qwalk(mol,m)

