### PR TITLE
SHCI_tools did not compile on gcc versions later than 6.

### DIFF
--- a/pyscf/lib/shciscf/SHCI_tools.cpp
+++ b/pyscf/lib/shciscf/SHCI_tools.cpp
@@ -277,7 +277,7 @@ extern "C"
 		{
 			if ( fabs( h1e[ i ] ) > tol )
 			{
-				div_t pq = div( i, norb );
+				div_t pq = div(static_cast<int>(i),static_cast<int>(norb) );
 				p = pq.rem + 1;
 				q = pq.quot + 1;
 				fOut << h1e[ i ] << "    " << p << "  " << q << endStr;


### PR DESCRIPTION
Needed a cast for div(). Note that it was implicitly using ints. I don't know if that will cause problems for high memory? Actually I don't know what SHCI does!