### PR TITLE
Update _runme_to_fix_dylib

### DIFF
--- a/pyscf/lib/_runme_to_fix_dylib_osx10.11.sh
+++ b/pyscf/lib/_runme_to_fix_dylib_osx10.11.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # On Mac OSX 10.11 or newer, you may get error message if you use clang compiler
 #
-#  OSError: dlopen(xxx/pyscf/lib/libcgto.dylib, 6): Library not loaded: libcint.2.8.dylib
+#  OSError: dlopen(xxx/pyscf/lib/libcgto.dylib, 6): Library not loaded: libcint.3.0.dylib
 #  Referenced from: xxx/pyscf/lib/libcgto.dylib
-#  Reason: unsafe use of relative rpath libcint.2.8.dylib in xxx/pyscf/lib/libao2mo.dylib with restricted binary
+#  Reason: unsafe use of relative rpath libcint.3.0.dylib in xxx/pyscf/lib/libao2mo.dylib with restricted binary
 #
 # It requires following fixing
 
@@ -12,6 +12,8 @@ dirnow=$(pwd)/$(dirname $0)
 cd $dirnow
 for i in *.dylib
 do
-  echo install_name_tool -change libcint.2.8.dylib ${dirnow}/deps/lib/libcint.2.8.dylib ${dirnow}/$i
-  install_name_tool -change libcint.2.8.dylib ${dirnow}/deps/lib/libcint.2.8.dylib ${dirnow}/$i
+  echo install_name_tool -change libcint.3.0.dylib ${dirnow}/deps/lib/libcint.3.0.dylib ${dirnow}/$i
+  install_name_tool -change libcint.3.0.dylib ${dirnow}/deps/lib/libcint.3.0.dylib ${dirnow}/$i
+  echo install_name_tool -change libxcfun.dylib ${dirnow}/deps/lib/libxcfun.dylib ${dirnow}/$i
+  install_name_tool -change libxcfun.dylib ${dirnow}/deps/lib/libxcfun.dylib ${dirnow}/$i
 done


### PR DESCRIPTION
- Libcint is now on 3.0
- I'm not sure if something changed in the build, but I had to patch the dylibs also for libxcfun