### PR TITLE
Pyscf/Pyberny interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,8 @@ CMakeCache.txt
 CMakeFiles
 Makefile
 cmake_install.cmake
-lib/deps
-lib/config.h
+pyscf/lib/deps
+pyscf/lib/config.h
 
 settings.py
 

--- a/pyscf/geomopt/berny_solver.py
+++ b/pyscf/geomopt/berny_solver.py
@@ -4,7 +4,7 @@ Interface to geometry optimizer pyberny
 '''
 from __future__ import absolute_import
 try:
-    from berny import Berny, geomlib, Logger
+    from berny import Berny, geomlib, Logger, optimize as optimize_berny
 except ImportError:
     raise ImportError('Geometry optimizer pyberny not found.\npyberny library '
                       'can be found on github https://github.com/azag0/pyberny')
@@ -51,10 +51,14 @@ def as_berny_solver(method, mol=None):
         atom = yield energy, gradients
 
 
+def optimize(method, mol, **kwargs):
+    optimize_berny(as_berny_solver(method), to_berny_geom(mol), **kwargs)
+    return method.mol
+
+
 if __name__ == '__main__':
     from pyscf import gto
     from pyscf import scf, dft, cc
-    from berny import optimize
     mol = gto.M(atom='''
 C       1.1879  -0.3829 0.0000
 C       0.0000  0.5526  0.0000
@@ -71,7 +75,10 @@ H       -0.0227 1.1812  -0.8852
 
     mf = scf.RHF(mol)
     print(kernel(mf).dumps('xyz'))
-    print(optimize(as_berny_solver(mf), to_berny_geom(mol)).dumps('xyz'))
+    print(optimize_berny(as_berny_solver(mf), to_berny_geom(mol)).dumps('xyz'))
+    mol0 = optimize(mf, mol1)
+    scf.RHF(mol1).kernel()
+    scf.RHF(mol0).kernel()
 
     mf = dft.RKS(mol)
     mf.xc = 'pbe'


### PR DESCRIPTION
As is, there are two suggestions in `pyscf.geomopt.berny_solver`:

- Function `kernel()` that takes a method and optionally a `mol` and optimizes either the given `mol` or the method's assigned `mol` (both side effects). Returns `pyberny.Molecule`.
- Convertors `as_berny_solver()` and `to_berny_geom()` that adapt Pyscf objects to be passed to `pyberny.optimize()`.

My comments:

- I'd suggest that on the highest API level, Pyberny should be invisible from Pyscf. So the convertors should be applied by Pyscf itself. No Pyscf functions should return Pyberny objects.
- I'd argue against any side effects. Also, in all other contexts in Pyscf, a function called "kernel" has no side effects and returns energy. So I wouldn't reuse that name for a function that has side effects and returns a foreign geometry object.

In this pull request, I suggest to wrap `pyberny.optimize()` with `pyscf.geomopt.optimize()` that does all this conversion internally.

Alternatively, we could wrap `pyberny.Berny()` in a similar way and `pyberny.optimize()` could take an optional `klass=` argument, so wrapping it would then by simply

```python
def optimize(method, mol, **kwargs):
    return pyberny.optimize(method, mol, klass=pyscf.geomopt.Berny, **kwargs)
```