### PR TITLE
Run on libxc functional keywords and add missing function declarations

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -581,13 +581,13 @@ def parse_xc(description):
         return list(zip(fn_ids, facs))
 
     if ',' in description:
-        x_code, c_code = description.replace(' ','').replace('_','').upper().split(',')
+        x_code, c_code = description.replace(' ','').upper().split(',')
         for token in x_code.replace('-', '+-').split('+'):
             parse_token(token, possible_x_for)
         for token in c_code.replace('-', '+-').split('+'):
             parse_token(token, possible_c_for)
     else:
-        x_code = description.replace(' ','').replace('_','').upper()
+        x_code = description.replace(' ','').upper()
         try:
             for token in x_code.replace('-', '+-').split('+'):
                 parse_token(token, possible_xc_for)

--- a/pyscf/lib/vhf/optimizer.c
+++ b/pyscf/lib/vhf/optimizer.c
@@ -13,6 +13,8 @@
 #define MAX(I,J)        ((I) > (J) ? (I) : (J))
 
 int int2e_sph();
+int GTOmax_cache_size(int (*intor)(), int *shls_slice, int ncenter,
+                      int *atm, int natm, int *bas, int nbas, double *env);
 
 void CVHFinit_optimizer(CVHFOpt **opt, int *atm, int natm,
                         int *bas, int nbas, double *env)

--- a/pyscf/lib/vhf/rkb_screen.c
+++ b/pyscf/lib/vhf/rkb_screen.c
@@ -22,6 +22,8 @@
 
 int int2e_spinor();
 int int2e_spsp1spsp2_spinor();
+int GTOmax_cache_size(int (*intor)(), int *shls_slice, int ncenter,
+                      int *atm, int natm, int *bas, int nbas, double *env);
 
 int CVHFrkbllll_prescreen(int *shls, CVHFOpt *opt,
                           int *atm, int *bas, double *env)


### PR DESCRIPTION
With this PR, functionals can be defined directly in terms of libxc keywords as e.g.
```mf.xc = 'GGA_X_PBE,GGA_C_PBE```

Also, two missing function declarations are added.

