### PR TITLE
Fixing 2D FFTDF

### DIFF
--- a/examples/pbc/32-graphene.py
+++ b/examples/pbc/32-graphene.py
@@ -25,8 +25,6 @@ from pyscf.pbc import tools
 nk = 1
 kpts = [nk,nk,1]
 Lz = 25 # Smallest Lz value for ~1e-6 convergence in absolute energy
-#fft_ke_cut = 300 # We need around accuracy of ~1e-6 for FFTDF
-#                 # Corresponds to mesh = [32,32,156]
 a = 1.42 # bond length in graphene
 fft_ke_cut = 300
 aft_mesh = [30,30,40] # Much smaller mesh needed for AFTDF
@@ -71,11 +69,12 @@ cell.build(unit = 'B',
            pseudo = pseudo,
            verbose = 7,
            precision = 1e-6,
+           low_dim_ft_type='analytic_2d_1'
            basis='gth-szv')
 t0 = time.time()
 mf = pbchf.KRHF(cell, exxdiv='ewald')
 #mf = pbchf.KRHF(cell, exxdiv=None)
-mf.with_df = pdf.FFTDF(cell, low_dim_ft_type='analytic_2d_1')
+mf.with_df = pdf.FFTDF(cell)
 mf.kpts = cell.make_kpts(kpts)
 mf.conv_tol = 1e-6
 e.append(mf.kernel())

--- a/pyscf/pbc/df/aft.py
+++ b/pyscf/pbc/df/aft.py
@@ -247,6 +247,12 @@ class AFTDF(lib.StreamObject):
     def check_sanity(self):
         lib.StreamObject.check_sanity(self)
         cell = self.cell
+        if cell.low_dim_ft_type is not None:
+            raise ValueError('AFTDF detected a non-None cell.low_dim_ft_type! '
+                             'The cell.low_dim_ft_type should only be \nset when '
+                             'using with_df = FFTDF. Please set mf.with_df equal '
+                             'to FFTDF or set cell.low_dim_ft_type \n(= %s) to None. '
+                              % (cell.low_dim_ft_type))
         if not cell.has_ecp():
             logger.warn(self, 'AFTDF integrals are found in all-electron '
                         'calculation.  It often causes huge error.\n'

--- a/pyscf/pbc/df/fft.py
+++ b/pyscf/pbc/df/fft.py
@@ -138,19 +138,13 @@ def get_pp(mydf, kpts=None):
 class FFTDF(lib.StreamObject):
     '''Density expansion on plane waves
     '''
-    def __init__(self, cell, kpts=numpy.zeros((1,3)), low_dim_ft_type=None):
+    def __init__(self, cell, kpts=numpy.zeros((1,3))):
         from pyscf.pbc.dft import numint
         self.cell = cell
         self.stdout = cell.stdout
         self.verbose = cell.verbose
         self.max_memory = cell.max_memory
-        if low_dim_ft_type is None:
-            self.low_dim_ft_type = cell.low_dim_ft_type
-        else:
-            logger.warn(self, 'Setting low_dim_ft_type inside cell class.  Change me in '
-                              'future implementation \n')
-            cell.low_dim_ft_type = low_dim_ft_type
-            self.low_dim_ft_type = low_dim_ft_type
+        self.low_dim_ft_type = cell.low_dim_ft_type
 
         self.kpts = kpts
         self.mesh = cell.mesh

--- a/pyscf/pbc/df/fft.py
+++ b/pyscf/pbc/df/fft.py
@@ -175,11 +175,11 @@ class FFTDF(lib.StreamObject):
         lib.StreamObject.check_sanity(self)
         cell = self.cell
         if cell.dimension < 2:
-            raise RuntimeError('FFTDF method does not support low-dimension '
+            raise RuntimeError('FFTDF method does not support 0D/1D low-dimension '
                                'PBC system.  DF, MDF or AFTDF methods should '
                                'be used.\nSee also examples/pbc/31-low_dimensional_pbc.py')
         if cell.dimension == 2 and self.low_dim_ft_type is None:
-            raise RuntimeError('FFTDF method only supports low_dim_ft_type of None '
+            raise RuntimeError('FFTDF method does not support low_dim_ft_type of None '
                                'for 2D systems.  Supported types include \'analytic_2d_1\'. '
                                '\nSee also examples/pbc/32-graphene.py')
 

--- a/pyscf/pbc/df/fft_ao2mo.py
+++ b/pyscf/pbc/df/fft_ao2mo.py
@@ -30,6 +30,7 @@ from pyscf.pbc.lib.kpts_helper import is_zero, gamma_point
 def get_eri(mydf, kpts=None, compact=False):
     cell = mydf.cell
     nao = cell.nao_nr()
+    low_dim_ft_type = cell.low_dim_ft_type
     kptijkl = _format_kpts(kpts)
     if not _iskconserv(cell, kptijkl):
         lib.logger.warn(cell, 'fft_ao2mo: momentum conservation not found in '
@@ -38,7 +39,7 @@ def get_eri(mydf, kpts=None, compact=False):
 
     kpti, kptj, kptk, kptl = kptijkl
     q = kptj - kpti
-    coulG = tools.get_coulG(cell, q, mesh=mydf.mesh)
+    coulG = tools.get_coulG(cell, q, mesh=mydf.mesh, low_dim_ft_type=low_dim_ft_type)
     coords = cell.gen_uniform_grids(mydf.mesh)
     max_memory = mydf.max_memory - lib.current_memory()[0]
 
@@ -85,6 +86,7 @@ def get_eri(mydf, kpts=None, compact=False):
 def general(mydf, mo_coeffs, kpts=None, compact=False):
     '''General MO integral transformation'''
     cell = mydf.cell
+    low_dim_ft_type = cell.low_dim_ft_type
     kptijkl = _format_kpts(kpts)
     kpti, kptj, kptk, kptl = kptijkl
     if isinstance(mo_coeffs, numpy.ndarray) and mo_coeffs.ndim == 2:
@@ -97,7 +99,7 @@ def general(mydf, mo_coeffs, kpts=None, compact=False):
 
     allreal = not any(numpy.iscomplexobj(mo) for mo in mo_coeffs)
     q = kptj - kpti
-    coulG = tools.get_coulG(cell, q, mesh=mydf.mesh)
+    coulG = tools.get_coulG(cell, q, mesh=mydf.mesh, low_dim_ft_type=low_dim_ft_type)
     coords = cell.gen_uniform_grids(mydf.mesh)
     max_memory = mydf.max_memory - lib.current_memory()[0]
 

--- a/pyscf/pbc/df/fft_jk.py
+++ b/pyscf/pbc/df/fft_jk.py
@@ -11,7 +11,7 @@ import numpy as np
 from pyscf import lib
 from pyscf.pbc import tools
 from pyscf.pbc.dft import numint
-from pyscf.pbc.df.df_jk import _format_dms, _format_kpts_band, _format_jks
+from pyscf.pbc.df.df_jk import _format_dms, _format_kpts_band, _format_jks, _ewald_exxdiv_for_G0
 from pyscf.pbc.lib.kpts_helper import is_zero, gamma_point
 
 
@@ -145,8 +145,16 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), kpts_band=None,
         for k1, ao1T in enumerate(ao1_kpts):
             kpt1 = kpts_band[k1]
             mydf.exxdiv = exxdiv
-            coulG = tools.get_coulG(cell, kpt2-kpt1, True, mydf, mesh,
-                                    low_dim_ft_type=low_dim_ft_type)
+
+            # If we have an ewald exxdiv, we add the G=0 correction near the
+            # end of the function to bypass any discretization errors
+            # that arise from the FFT.
+            if exxdiv == 'ewald' or exxdiv is None:
+                coulG = tools.get_coulG(cell, kpt2-kpt1, False, mydf, mesh,
+                                        low_dim_ft_type=low_dim_ft_type)
+            else:
+                coulG = tools.get_coulG(cell, kpt2-kpt1, True, mydf, mesh,
+                                        low_dim_ft_type=low_dim_ft_type)
             if is_zero(kpt1-kpt2):
                 expmikr = np.array(1.)
             else:
@@ -168,6 +176,10 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), kpts_band=None,
 
             for i in range(nset):
                 vk_kpts[i,k1] += weight * lib.dot(vR_dm[i], ao1T.T)
+
+    # Add back in the G=0 component to vk_kpts
+    if exxdiv == 'ewald':
+        _ewald_exxdiv_for_G0(cell, kpts, dms, vk_kpts, kpts_band=kpts_band)
 
     return _format_jks(vk_kpts, dm_kpts, input_band, kpts)
 

--- a/pyscf/pbc/df/test/test_band.py
+++ b/pyscf/pbc/df/test/test_band.py
@@ -40,8 +40,8 @@ class KnowValues(unittest.TestCase):
         mf = scf.KRHF(cell)
         mf.kpts = cell.make_kpts([2]*3)
         mf.kernel()
-        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), -0.26538705237640059, 8)
-        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), -0.65622644106336381, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), -0.26539150034518982, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), -0.6562304384317044, 8)
 
     def test_aft_bands(self):
         mf = scf.KRHF(cell)

--- a/pyscf/pbc/scf/test/test_hf.py
+++ b/pyscf/pbc/scf/test/test_hf.py
@@ -191,6 +191,39 @@ class KnowValues(unittest.TestCase):
         e1 = mf.kernel()
         self.assertAlmostEqual(e1, -3.2681555164454039, 5)
 
+    def test_rhf_2d_fft(self):
+        L = 4
+        cell = pbcgto.Cell()
+        cell.build(unit = 'B',
+                   a = [[L,0,0],[0,L,0],[0,0,L*5]],
+                   mesh = [11,11,20],
+                   atom = '''He 2 0 0; He 3 0 0''',
+                   dimension = 2,
+                   low_dim_ft_type = 'analytic_2d_1',
+                   verbose = 0,
+                   basis = { 'He': [[0, (0.8, 1.0)],
+                                    [0, (1.2, 1.0)]
+                                   ]})
+        mf = pbchf.RHF(cell, exxdiv='ewald')
+        mf.with_df = pdf.FFTDF(cell)
+        mf.with_df.mesh = cell.mesh
+        e1 = mf.kernel()
+        self.assertAlmostEqual(e1, -3.5797041803667593, 5)
+
+        mf1 = pbchf.RHF(cell, exxdiv='ewald')
+        mf1.with_df = pdf.FFTDF(cell)
+        mf1.with_df.mesh = cell.mesh
+        mf1.direct_scf = True
+        e1 = mf1.kernel()
+        self.assertAlmostEqual(e1, -3.5797041803667593, 5)
+
+        mf2 = pbchf.RHF(cell, exxdiv=None)
+        mf2.with_df = pdf.FFTDF(cell)
+        mf2.with_df.mesh = cell.mesh
+        mf2.direct_scf = True
+        e2 = mf2.kernel()
+        self.assertAlmostEqual(e2, -1.629571720365774, 5)
+
     def test_get_veff(self):
         mf = pscf.RHF(cell)
         numpy.random.seed(1)


### PR DESCRIPTION
I realized there were a couple of things that needed to be fixed in the 2D FFT concerning proper behavior for ewald exchange treatment as well as ERI creation.  A full list of changes is given below:

- Fixed a number of warning/error messages concerning the use of the low_dim_ft_type with other density fitting techniques such as AFTDF.

- Fixed the low-dimensional FFT treatment within the fft_ao2mo module.

- When given eri's explicitly the HF energy would be different than if they weren't given explicitly.  This would only happen if the mesh grid weren't large enough, but having similar behavior for both cases is nice.

I've added a few tests as well and updated some other tests based on this change in how the ewald exchange divergence is treated.