### PR TITLE
Fixed eval_gto for low-dimensional systems

### DIFF
--- a/pyscf/pbc/gto/eval_gto.py
+++ b/pyscf/pbc/gto/eval_gto.py
@@ -113,7 +113,9 @@ def eval_gto(cell, eval_name, coords, comp=None, kpts=None, kpt=None,
     out_ptrs = (ctypes.c_void_p*nkpts)(
             *[x.ctypes.data_as(ctypes.c_void_p) for x in ao_kpts])
     coords = numpy.asarray(coords, order='F')
-    Ls = cell.get_lattice_Ls(dimension=cell.dimension)
+    # For atoms near the boundary of the cell, it is necessary (even in low-
+    # dimensional systems) to include lattice translations in all 3 dimensions.
+    Ls = cell.get_lattice_Ls(dimension=3)
     Ls = Ls[numpy.argsort(lib.norm(Ls, axis=1))]
     expLk = numpy.exp(1j * numpy.asarray(numpy.dot(Ls, kpts_lst.T), order='C'))
 


### PR DESCRIPTION
For systems with reduced periodicity, there were problems when the summation of lattice vectors in the non-periodic direction was not included.  These effects were most noticeable when the atoms were situated near the cell boundary and only affects the FFTDF methods (since the AFTDF does not seem to use this function).

This fixes one of the tests in pbc/scf/test_hf.py