### PR TITLE
Fix bug when deserialising cell object.

### DIFF
--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -240,7 +240,7 @@ def loads(cellstr):
     cell.atom = eval(cell.atom)
     cell.basis = eval(cell.basis)
     cell.pseudo = eval(cell.pseudo)
-    cell.pseudo = eval(cell.ecp)
+    cell.ecp = eval(cell.ecp)
     cell._atm = np.array(cell._atm, dtype=np.int32)
     cell._bas = np.array(cell._bas, dtype=np.int32)
     cell._env = np.array(cell._env, dtype=np.double)


### PR DESCRIPTION
The following prevents cell.pseudo being overwritten when deserialising a cell object.

Original code:
https://github.com/sunqm/pyscf/blob/c37cfbabc8373815aadf8b11315d9235cc3d2498/pyscf/pbc/gto/cell.py#L242-L243