### PR TITLE
Frozen virtual

### DIFF
--- a/pyscf/pbc/cc/test/test_kpoint.py
+++ b/pyscf/pbc/cc/test/test_kpoint.py
@@ -112,7 +112,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ehf, ehf_bench, 9)
         self.assertAlmostEqual(ecc, ecc_bench, 9)
 
- 5   def _test_cu_metallic_nonequal_occ(self, kmf, cell, nk=[1,1,1]):
+    def _test_cu_metallic_nonequal_occ(self, kmf, cell, nk=[1,1,1]):
         assert cell.mesh == [7, 7, 7]
         ecc1_bench = -1.1633910051553982
         max_cycle = 2  # Too expensive to do more!

--- a/pyscf/pbc/cc/test/test_kpoint.py
+++ b/pyscf/pbc/cc/test/test_kpoint.py
@@ -112,33 +112,72 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ehf, ehf_bench, 9)
         self.assertAlmostEqual(ecc, ecc_bench, 9)
 
-    def test_frozen_n3(self):
-        mesh = 5
-        cell = make_test_cell.test_cell_n3([mesh]*3)
-        nk = (1, 1, 3)
-        ehf_bench = -9.15349763559837
-        ecc_bench = -0.06713556649654
+ 5   def _test_cu_metallic_nonequal_occ(self, kmf, cell, nk=[1,1,1]):
+        assert cell.mesh == [7, 7, 7]
+        ecc1_bench = -1.1633910051553982
+        max_cycle = 2  # Too expensive to do more!
 
-        abs_kpts = cell.make_kpts(nk, with_gamma_point=True)
+        # The following calculation at full convergence gives -0.711071910294612
+        # for a cell.mesh = [25, 25, 25].
+        mycc = pyscf.pbc.cc.KGCCSD(kmf, frozen=0)
+        mycc.iterative_damping = 0.04
+        mycc.max_cycle = max_cycle
+        ecc1, t1, t2 = mycc.kernel()
 
-        # RHF calculation
-        kmf = pbchf.KRHF(cell, abs_kpts, exxdiv=None)
-        ehf = kmf.scf()
+        self.assertAlmostEqual(ecc1, ecc1_bench, 6)
 
-        # KGCCSD calculation, equivalent to running supercell
-        # calculation with frozen=[0, 1, 2] (if done with larger mesh)
-        cc = pyscf.pbc.cc.kccsd.CCSD(kmf, frozen=[[0,1],[],[0]])
-        ecc, t1, t2 = cc.kernel()
-        self.assertAlmostEqual(ehf, ehf_bench, 9)
-        self.assertAlmostEqual(ecc, ecc_bench, 9)
+    def _test_cu_metallic_frozen_occ(self, kmf, cell, nk=[1,1,1]):
+        assert cell.mesh == [7, 7, 7]
+        ecc2_bench = -1.0430822430909346
+        max_cycle = 2
+
+        # The following calculation at full convergence gives -0.6440448716452378
+        # for a cell.mesh = [25, 25, 25].  It is equivalent to a supercell [1, 1, 2]
+        # calculation with frozen = [0, 3].
+        mycc = pyscf.pbc.cc.KGCCSD(kmf, frozen=[[2, 3], [0, 1]])
+        mycc.iterative_damping = 0.04
+        mycc.max_cycle = max_cycle
+        ecc2, t1, t2 = mycc.kernel()
+
+        self.assertAlmostEqual(ecc2, ecc2_bench, 6)
+
+    def _test_cu_metallic_frozen_vir(self, kmf, cell, nk=[1,1,1]):
+        assert cell.mesh == [7, 7, 7]
+        ecc3_bench = -0.94610600274627665
+        max_cycle = 2
+
+        # The following calculation at full convergence gives -0.58688462599474
+        # for a cell.mesh = [25, 25, 25].  It is equivalent to a supercell [1, 1, 2]
+        # calculation with frozen = [0, 3, 35].
+        mycc = pyscf.pbc.cc.KGCCSD(kmf, frozen=[[2, 3, 34, 35], [0, 1]])
+        mycc.max_cycle = max_cycle
+        mycc.iterative_damping = 0.05
+        ecc3, t1, t2 = mycc.kernel()
+
+        self.assertAlmostEqual(ecc3, ecc3_bench, 6)
+
+        check_gamma = False  # Turn me on to run the supercell calculation!
+
+        if check_gamma:
+            from pyscf.pbc.tools.pbc import super_cell
+            supcell = super_cell(cell, nk)
+            kmf = pbchf.RHF(supcell, exxdiv=None)
+            ehf = kmf.scf()
+
+            mycc = pyscf.pbc.cc.RCCSD(kmf, frozen=[0, 3, 35])
+            mycc.max_cycle = max_cycle
+            mycc.iterative_damping = 0.05
+            ecc, t1, t2 = mycc.kernel()
+
+            print('Gamma energy =', ecc/np.prod(nk))
+            print('K-point energy =', ecc3)
 
     def test_cu_metallic(self):
         mesh = 7
         cell = make_test_cell.test_cell_cu_metallic([mesh]*3)
         nk = [1,1,2]
+
         ehf_bench = -52.5393701339723
-        ecc1_bench = -1.1633910051553982
-        ecc2_bench = -1.0430822430909346
 
         # KRHF calculation
         kmf = pbchf.KRHF(cell, exxdiv=None)
@@ -148,24 +187,10 @@ class KnownValues(unittest.TestCase):
 
         self.assertAlmostEqual(ehf, ehf_bench, 6)
 
-        # The following calculation at full convergence gives -0.711071910294612
-        # for a cell.mesh = [25, 25, 25].
-        mycc = pyscf.pbc.cc.KGCCSD(kmf, frozen=0)
-        mycc.iterative_damping = 0.04
-        mycc.max_cycle = 2  # Too expensive to do more!
-        ecc1, t1, t2 = mycc.kernel()
-
-        self.assertAlmostEqual(ecc1, ecc1_bench, 6)
-
-        # The following calculation at full convergence gives -0.6440448716452378
-        # for a cell.mesh = [25, 25, 25].  It is equivalent to a supercell [1, 1, 2]
-        # calculation with frozen = [0, 3].
-        mycc = pyscf.pbc.cc.KGCCSD(kmf, frozen=[[2, 3], [0, 1]])
-        mycc.iterative_damping = 0.04
-        mycc.max_cycle = 2
-        ecc2, t1, t2 = mycc.kernel()
-
-        self.assertAlmostEqual(ecc2, ecc2_bench, 6)
+        # Run CC calculations
+        self._test_cu_metallic_nonequal_occ(kmf, cell, nk=nk)
+        self._test_cu_metallic_frozen_occ(kmf, cell, nk=nk)
+        self._test_cu_metallic_frozen_vir(kmf, cell, nk=nk)
 
     def test_ccsd_t(self):
         n = 14

--- a/pyscf/pbc/cc/test/test_kpoint_rhf.py
+++ b/pyscf/pbc/cc/test/test_kpoint_rhf.py
@@ -107,13 +107,71 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ehf, ehf_bench, 9)
         self.assertAlmostEqual(ecc, ecc_bench, 9)
 
+    def _test_cu_metallic_nonequal_occ(self, kmf, cell, nk=[1,1,1]):
+        assert cell.mesh == [7, 7, 7]
+        ecc1_bench = -0.9646107739333411
+        max_cycle = 5  # Too expensive to do more
+
+        # The following calculation at full convergence gives -0.711071910294612
+        # for a cell.mesh = [25, 25, 25].
+        mycc = pyscf.pbc.cc.kccsd_rhf.RCCSD(kmf, frozen=0)
+        mycc.iterative_damping = 0.05
+        mycc.max_cycle = max_cycle
+        ecc1, t1, t2 = mycc.kernel()
+
+        self.assertAlmostEqual(ecc1, ecc1_bench, 6)
+
+    def _test_cu_metallic_frozen_occ(self, kmf, cell, nk=[1,1,1]):
+        assert cell.mesh == [7, 7, 7]
+        ecc2_bench = -0.7651806468801496
+        max_cycle = 5
+
+        # The following calculation at full convergence gives -0.6440448716452378
+        # for a cell.mesh = [25, 25, 25].  It is equivalent to an RHF supercell [1, 1, 2]
+        # calculation with frozen = [0, 3].
+        mycc = pyscf.pbc.cc.kccsd_rhf.RCCSD(kmf, frozen=[[2, 3], [0, 1]])
+        mycc.iterative_damping = 0.05
+        mycc.max_cycle = max_cycle
+        ecc2, t1, t2 = mycc.kernel()
+
+        self.assertAlmostEqual(ecc2, ecc2_bench, 6)
+
+    def _test_cu_metallic_frozen_vir(self, kmf, cell, nk=[1,1,1]):
+        assert cell.mesh == [7, 7, 7]
+        ecc3_bench = -0.76794053711557086
+        max_cycle = 5
+
+        # The following calculation at full convergence gives -0.58688462599474
+        # for a cell.mesh = [25, 25, 25].  It is equivalent to a supercell [1, 1, 2]
+        # calculation with frozen = [0, 3, 35].
+        mycc = pyscf.pbc.cc.kccsd_rhf.RCCSD(kmf, frozen=[[1, 17], [0]])
+        mycc.max_cycle = max_cycle
+        mycc.iterative_damping = 0.05
+        ecc3, t1, t2 = mycc.kernel()
+
+        self.assertAlmostEqual(ecc3, ecc3_bench, 6)
+
+        check_gamma = False  # Turn me on to run the supercell calculation!
+
+        if check_gamma:
+            from pyscf.pbc.tools.pbc import super_cell
+            supcell = super_cell(cell, nk)
+            kmf = pbcscf.RHF(supcell, exxdiv=None)
+            ehf = kmf.scf()
+
+            mycc = pyscf.pbc.cc.RCCSD(kmf, frozen=[0, 3, 35])
+            mycc.max_cycle = max_cycle
+            mycc.iterative_damping = 0.05
+            ecc, t1, t2 = mycc.kernel()
+
+            print('Gamma energy =', ecc/np.prod(nk))
+            print('K-point energy =', ecc3)
+
     def test_cu_metallic(self):
         mesh = 7
         cell = make_test_cell.test_cell_cu_metallic([mesh]*3)
         nk = [1,1,2]
         ehf_bench = -52.5393701339723
-        ecc1_bench = -0.9646107739333411
-        ecc2_bench = -0.7651806468801496
 
         # KRHF calculation
         kmf = pbcscf.KRHF(cell, exxdiv=None)
@@ -123,24 +181,10 @@ class KnownValues(unittest.TestCase):
 
         self.assertAlmostEqual(ehf, ehf_bench, 6)
 
-        # The following calculation at full convergence gives -0.711071910294612
-        # for a cell.mesh = [25, 25, 25].
-        mycc = pyscf.pbc.cc.kccsd_rhf.RCCSD(kmf, frozen=0)
-        mycc.iterative_damping = 0.05
-        mycc.max_cycle = 5  # Too expensive to do more
-        ecc1, t1, t2 = mycc.kernel()
-
-        self.assertAlmostEqual(ecc1, ecc1_bench, 6)
-
-        # The following calculation at full convergence gives -0.6440448716452378
-        # for a cell.mesh = [25, 25, 25].  It is equivalent to an RHF supercell [1, 1, 2]
-        # calculation with frozen = [0, 3].
-        mycc = pyscf.pbc.cc.kccsd_rhf.RCCSD(kmf, frozen=[[2, 3], [0, 1]])
-        mycc.iterative_damping = 0.05
-        mycc.max_cycle = 5
-        ecc2, t1, t2 = mycc.kernel()
-
-        self.assertAlmostEqual(ecc2, ecc2_bench, 6)
+        # Run CC calculations
+        self._test_cu_metallic_nonequal_occ(kmf, cell, nk=nk)
+        self._test_cu_metallic_frozen_occ(kmf, cell, nk=nk)
+        self._test_cu_metallic_frozen_vir(kmf, cell, nk=nk)
 
     def test_ccsd_t(self):
         n = 14

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -170,11 +170,9 @@ def get_nmo(mp, per_kpoint=False):
     frozen orbitals.
 
     Note:
-        If per_kpoint is False, then the number of orbitals here is the same at every k-point,
-        regardless of whether there are a different number of occupied orbitals per k-point.
-        To do this, it will "pad" some k-points so that each k-point has a number of orbitals
-        equal to max(noccupied orbitals) + max(nvirtual orbitals), where each max is done over
-        all k-points.  This only removes a frozen orbital if its frozen at every k-point.
+        If `per_kpoint` is False, then the number of orbitals here is equal to max(nocc) + max(nvir),
+        where each max is done over all k-points.  Otherwise the number of orbitals is returned
+        as a list of number of orbitals at each k-point.
 
     Args:
         mp (:class:`MP2`): An instantiation of an MP2, SCF, or other mean-field object.

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -90,10 +90,13 @@ def _frozen_sanity_check(frozen, mo_occ, kpt_idx):
     nocc = np.count_nonzero(mo_occ > 0)
     nvir = len(mo_occ) - nocc
     assert nocc, 'No occupied orbitals?\n\nnocc = %s\nmo_occ = %s' % (nocc, mo_occ)
-    diff = len(frozen) - len(np.unique(frozen))
-    if diff > 0:
+    all_frozen_unique = (len(frozen) - len(np.unique(frozen))) == 0
+    if not all_frozen_unique:
         raise RuntimeError('Frozen orbital list contains duplicates!\n\nkpt_idx %s\n'
                            'frozen %s' % (kpt_idx, frozen))
+    if len(frozen) > 0 and np.max(frozen) > len(mo_occ) - 1:
+        raise RuntimeError('Freezing orbital not in MO list!\n\nkpt_idx %s\n'
+                           'frozen %s\nmax orbital %s' % (kpt_idx, frozen, len(mo_occ-1)))
 
     occ_idx = np.where(mo_occ > 0)
     max_occ_idx = np.max(occ_idx)

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -75,9 +75,9 @@ def kernel(mp, mo_energy, mo_coeff, verbose=logger.NOTE):
 def _frozen_sanity_check(frozen, mo_occ, kpt_idx):
     '''Performs a few sanity checks on the frozen array and mo_occ.
 
-    Specific tests include checking for duplicates within the frozen array,
-    making sure we only freeze occupied orbitals, and making sure we didn't
-    freeze all the occupied orbitals.
+    Specific tests include checking for duplicates within the frozen array
+    and making sure we didn't freeze either all the occupied orbitals or all
+    the unoccupied orbitals.
 
     Args:
         frozen (array_like of int): The orbital indices that will be frozen.
@@ -86,21 +86,25 @@ def _frozen_sanity_check(frozen, mo_occ, kpt_idx):
         kpt_idx (int): The k-point that `mo_occ` and `frozen` belong to.
 
     '''
+    frozen = np.array(frozen)
     nocc = np.count_nonzero(mo_occ > 0)
+    nvir = len(mo_occ) - nocc
     assert nocc, 'No occupied orbitals?\n\nnocc = %s\nmo_occ = %s' % (nocc, mo_occ)
     diff = len(frozen) - len(np.unique(frozen))
     if diff > 0:
         raise RuntimeError('Frozen orbital list contains duplicates!\n\nkpt_idx %s\n'
                            'frozen %s' % (kpt_idx, frozen))
 
-    max_occ_idx = np.max(np.where(mo_occ > 0))
-    if any(np.array(frozen) > max_occ_idx):
-        raise RuntimeError('Freezing virtual orbitals is not allowed\n\n'
+    occ_idx = np.where(mo_occ > 0)
+    max_occ_idx = np.max(occ_idx)
+    frozen_nocc = len(frozen[frozen <= max_occ_idx])
+    if frozen_nocc >= nocc:
+        raise RuntimeError('Cannot freeze all occupied orbitals!:\n\n'
                            'kpt_idx %s\nfrozen %s\nmo_occ %s' % (kpt_idx, frozen, mo_occ))
 
-    nfrozen = len(frozen)
-    if nfrozen >= nocc:
-        raise RuntimeError('Must freeze less orbitals than occupied!:\n\n'
+    frozen_nvir = len(frozen[frozen > max_occ_idx])
+    if frozen_nvir >= nvir:
+        raise RuntimeError('Cannot freeze all virtual orbitals!:\n\n'
                            'kpt_idx %s\nfrozen %s\nmo_occ %s' % (kpt_idx, frozen, mo_occ))
 
 
@@ -126,22 +130,24 @@ def get_nocc(mp, per_kpoint=False):
         nocc = [(np.count_nonzero(mp.mo_occ[ikpt]) - mp.frozen) for ikpt in range(mp.nkpts)]
     elif isinstance(mp.frozen[0], (int, np.integer)):
         [_frozen_sanity_check(mp.frozen, mp.mo_occ[ikpt], ikpt) for ikpt in range(mp.nkpts)]
-        nocc = [(np.count_nonzero(mp.mo_occ[ikpt]) - len(mp.frozen)) for ikpt in range(mp.nkpts)]
+        nocc = []
+        for ikpt in range(mp.nkpts):
+            max_occ_idx = np.max(np.where(mp.mo_occ[ikpt] > 0))
+            frozen_nocc = np.sum(np.array(mp.frozen) <= max_occ_idx)
+            nocc.append(np.count_nonzero(mp.mo_occ[ikpt]) - frozen_nocc)
     elif isinstance(mp.frozen[0], (list, np.ndarray)):
         nkpts = len(mp.frozen)
         if nkpts != mp.nkpts:
             raise RuntimeError('Frozen list has a different number of k-points (length) than passed in mean-field/'
                                'correlated calculation.  \n\nCalculation nkpts = %d, frozen list = %s '
                                '(length = %d)' % (mp.nkpts, mp.frozen, nkpts))
-        [_frozen_sanity_check(fro, mo_occ, ikpt) for ikpt, fro, mo_occ in zip(range(nkpts), mp.frozen, mp.mo_occ)]
-        occ_idx = [mp.mo_occ[ikpt] > 0 for ikpt in range(nkpts)]
+        [_frozen_sanity_check(frozen, mo_occ, ikpt) for ikpt, frozen, mo_occ in zip(range(nkpts), mp.frozen, mp.mo_occ)]
 
-        ## Find where MO is frozen at every k-point and don't include this orbital
-        #all_frozen = reduce(set.intersection, [set(x) for x in mp.frozen])
-        for ikpt, fro in enumerate(mp.frozen):
-            occ_idx[ikpt][list(fro)] = False
-
-        nocc = [np.count_nonzero(occ_idx[ikpt]) for ikpt in range(nkpts)]
+        nocc = []
+        for ikpt, frozen in enumerate(mp.frozen):
+            max_occ_idx = np.max(np.where(mp.mo_occ[ikpt] > 0))
+            frozen_nocc = np.sum(np.array(frozen) <= max_occ_idx)
+            nocc.append(np.count_nonzero(mp.mo_occ[ikpt]) - frozen_nocc)
     else:
         raise NotImplementedError
 

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -96,7 +96,7 @@ def _frozen_sanity_check(frozen, mo_occ, kpt_idx):
                            'frozen %s' % (kpt_idx, frozen))
     if len(frozen) > 0 and np.max(frozen) > len(mo_occ) - 1:
         raise RuntimeError('Freezing orbital not in MO list!\n\nkpt_idx %s\n'
-                           'frozen %s\nmax orbital %s' % (kpt_idx, frozen, len(mo_occ-1)))
+                           'frozen %s\nmax orbital idx %s' % (kpt_idx, frozen, len(mo_occ) - 1))
 
     occ_idx = np.where(mo_occ > 0)
     max_occ_idx = np.max(occ_idx)

--- a/pyscf/pbc/mp/test/test_mask.py
+++ b/pyscf/pbc/mp/test/test_mask.py
@@ -67,6 +67,16 @@ class KnownValues(unittest.TestCase):
         self.assertRaises(RuntimeError, get_nocc, mp)
         self.assertRaises(RuntimeError, get_nmo, mp)  # Fails because it pads by calling get_nocc
 
+        # Freeze virtual not contained in set
+        mp = fake_mp(frozen=[4, 5], mo_occ=[np.array([2, 2, 2, 0, 0]), np.array([2, 2, 0, 0, 0])], nkpts=2)
+        self.assertRaises(RuntimeError, get_nocc, mp)
+        self.assertRaises(RuntimeError, get_nmo, mp)  # Fails because it pads by calling get_nocc
+
+    def test_frozen_repeated_orbital(self):
+        mp = fake_mp(frozen=[[1, 1], [0]], mo_occ=[np.array([2, 2, 2, 0, 0]), np.array([2, 2, 0, 0, 0])], nkpts=2)
+        self.assertRaises(RuntimeError, get_nocc, mp)
+        self.assertRaises(RuntimeError, get_nmo, mp)  # Fails because it pads by calling get_nocc
+
     def test_frozen_kpt_list1(self):
         mp = fake_mp(frozen=[[0, 1,], [0]], mo_occ=[np.array([2, 2, 2, 0, 0]), np.array([2, 2, 0, 0, 0])], nkpts=2)
         nocc = get_nocc(mp)

--- a/pyscf/pbc/mp/test/test_mask.py
+++ b/pyscf/pbc/mp/test/test_mask.py
@@ -62,6 +62,11 @@ class KnownValues(unittest.TestCase):
         self.assertRaises(RuntimeError, get_nocc, mp, per_kpoint=True)
         self.assertRaises(RuntimeError, get_nmo, mp, per_kpoint=True)
 
+        # Freeze all virtual at the first k-point
+        mp = fake_mp(frozen=[3, 4], mo_occ=[np.array([2, 2, 2, 0, 0]), np.array([2, 2, 0, 0, 0])], nkpts=2)
+        self.assertRaises(RuntimeError, get_nocc, mp)
+        self.assertRaises(RuntimeError, get_nmo, mp)  # Fails because it pads by calling get_nocc
+
     def test_frozen_kpt_list1(self):
         mp = fake_mp(frozen=[[0, 1,], [0]], mo_occ=[np.array([2, 2, 2, 0, 0]), np.array([2, 2, 0, 0, 0])], nkpts=2)
         nocc = get_nocc(mp)
@@ -85,6 +90,30 @@ class KnownValues(unittest.TestCase):
         nmo = get_nmo(mp, per_kpoint=True)
         self.assertListEqual(nocc, [1, 3, 2])
         self.assertListEqual(nmo, [3, 5, 4])
+
+    def test_frozen_kpt_list3(self):
+        mp = fake_mp(frozen=[[0,1,3],[3],[0]], mo_occ=[np.array([2, 2, 2, 0, 0])] * 3, nkpts=3)
+        nocc = get_nocc(mp)
+        nmo = get_nmo(mp)
+        self.assertAlmostEqual(nocc, 3)
+        self.assertAlmostEqual(nmo, 5)  # 2nd k-point has 3 occupied and 2 virtual orbitals
+
+        nocc = get_nocc(mp, per_kpoint=True)
+        nmo = get_nmo(mp, per_kpoint=True)
+        self.assertListEqual(nocc, [1, 3, 2])
+        self.assertListEqual(nmo, [2, 4, 4])
+
+    def test_frozen_kpt_list3(self):
+        mp = fake_mp(frozen=[[0,1,3],[3],[0]], mo_occ=[np.array([2, 2, 2, 0, 0])] * 3, nkpts=3)
+        nocc = get_nocc(mp)
+        nmo = get_nmo(mp)
+        self.assertAlmostEqual(nocc, 3)
+        self.assertAlmostEqual(nmo, 5)  # 2nd k-point has 3 occupied and 2 virtual orbitals
+
+        nocc = get_nocc(mp, per_kpoint=True)
+        nmo = get_nmo(mp, per_kpoint=True)
+        self.assertListEqual(nocc, [1, 3, 2])
+        self.assertListEqual(nmo, [2, 4, 4])
 
 if __name__ == '__main__':
     print("Full mask test")


### PR DESCRIPTION
Removed the restriction on post-hartree-fock k-point calculations that only allowed occupied orbitals to be frozen.  Now virtual orbitals can be frozen.