### PR TITLE
Fail quietly when not enough electrons to excite

### DIFF
--- a/pyscf/ci/cisd.py
+++ b/pyscf/ci/cisd.py
@@ -213,7 +213,9 @@ def tn_addrs_signs(norb, nelec, n_excite):
     the signs of the coefficients when transferring the reference from physics
     vacuum to HF vacuum.
     '''
-    assert(n_excite <= nelec)
+    if n_excite > nelec:
+        print("Warning: Not enough occupied orbitals to excite.")
+        return 0, 0
     nocc = nelec
 
     hole_strs = cistring.gen_strings4orblist(range(nocc), nocc - n_excite)


### PR DESCRIPTION
The ci/20-from-ci.py example doesn't work when there are less than 4 alpha or 4 beta electrons because of this line of code. 

In the case of a system like H4, then the preferred behavior might be to return something that evaluates to False, so then we can set aaaa or bbbb blocks to zero, while still keeping the aabb blocks.