### PR TITLE
make python3 find reduce

### DIFF
--- a/pyscf/__init__.py
+++ b/pyscf/__init__.py
@@ -37,6 +37,7 @@ to try out the package::
 
 __version__ = '1.5.3'
 
+from functools import reduce
 import os
 import sys
 from distutils.version import LooseVersion


### PR DESCRIPTION
"NameError: name 'reduce' is not defined" because reduce is moved to functools in python3.
No problem with python2 after this change since reduce were added to functools as a synonym for built-in reduce since python2.6 for compatibility.  