### PR TITLE
Additional guess for initial UHF density matrix

### DIFF
--- a/examples/scf/56-h2_symm_breaking.py
+++ b/examples/scf/56-h2_symm_breaking.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# Author: James D Whitfield <jdwhitfield@gmail.com>
+'''
+Scan H2 molecule dissociation curve comparing UHF and RHF solutions
+
+The initial guess available for 
+
+See also 16-h2_scan.py, 30-scan_pes.py, 32-break_spin_symm.py
+'''
+
+import numpy
+import pyscf
+from pyscf import scf
+from pyscf import gto
+
+erhf = []
+euhf = []
+dm = None
+
+
+def init_guess_mixed(mol,mixing_parameter=numpy.pi/4):
+    ''' Generate density matrix with broken spatial and spin symmetry by mixing
+    HOMO and LUMO orbitals following ansatz in Szabo and Ostlund, Sec 3.8.7.
+    
+    psi_1a = numpy.cos(q)*psi_homo + numpy.sin(q)*psi_lumo
+    psi_1b = numpy.cos(q)*psi_homo - numpy.sin(q)*psi_lumo
+        
+    psi_2a = -numpy.sin(q)*psi_homo + numpy.cos(q)*psi_lumo
+    psi_2b =  numpy.sin(q)*psi_homo + numpy.cos(q)*psi_lumo
+
+    Returns: 
+        Density matrices, a list of 2D ndarrays for alpha and beta spins
+    '''
+    # opt: q, mixing parameter 0 < q < 2 pi
+    
+    #based on init_guess_by_1e
+    h1e = scf.hf.get_hcore(mol)
+    s1e = scf.hf.get_ovlp(mol)
+    mo_energy, mo_coeff = rhf.eig(h1e, s1e)
+    mo_occ = rhf.get_occ(mo_energy=mo_energy, mo_coeff=mo_coeff)
+
+    homo_idx=0
+    lumo_idx=1
+
+    for i in range(len(mo_occ)-1):
+        if mo_occ[i]>0 and mo_occ[i+1]<0:
+            homo_idx=i
+            lumo_idx=i+1
+
+    psi_homo=mo_coeff[:, homo_idx]
+    psi_lumo=mo_coeff[:, lumo_idx]
+    
+    Ca=numpy.zeros_like(mo_coeff)
+    Cb=numpy.zeros_like(mo_coeff)
+
+
+    #mix homo and lumo of alpha and beta coefficients
+    q=mixing_parameter
+
+    for k in range(mo_coeff.shape[0]):
+        if k == homo_idx:
+            Ca[:,k] = numpy.cos(q)*psi_homo + numpy.sin(q)*psi_lumo
+            Cb[:,k] = numpy.cos(q)*psi_homo - numpy.sin(q)*psi_lumo
+            continue
+        if k==lumo_idx:
+            Ca[:,k] = -numpy.sin(q)*psi_homo + numpy.cos(q)*psi_lumo
+            Cb[:,k] =  numpy.sin(q)*psi_homo + numpy.cos(q)*psi_lumo
+            continue
+        Ca[:,k]=mo_coeff[:,k]
+        Cb[:,k]=mo_coeff[:,k]
+
+    dm =scf.UHF(mol).make_rdm1( (Ca,Cb), (mo_occ,mo_occ) )
+    return dm 
+
+
+for b in numpy.arange(0.7, 4.01, 0.1):
+    mol = gto.M(atom=[["H", 0., 0., 0.],
+                      ["H", 0., 0., b ]], basis='sto-3g', verbose=0)
+    rhf = scf.RHF(mol)
+    uhf = scf.UHF(mol)
+    erhf.append(rhf.kernel(dm))
+    euhf.append(uhf.kernel(init_guess_mixed(mol)))
+    dm = rhf.make_rdm1()
+
+print('R     E(RHF)      E(UHF)')
+for i, b in enumerate(numpy.arange(0.7, 4.01, 0.1)):
+    print('%.2f  %.8f  %.8f' % (b, erhf[i], euhf[i]))

--- a/examples/scf/56-h2_symm_breaking.py
+++ b/examples/scf/56-h2_symm_breaking.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # Author: James D Whitfield <jdwhitfield@gmail.com>
 '''
-Scan H2 molecule dissociation curve comparing UHF and RHF solutions
+Scan H2 molecule dissociation curve comparing UHF and RHF solutions per the 
+example of Szabo and Ostlund section 3.8.7
 
-The initial guess available for 
+The initial guess is obtained by mixing the HOMO and LUMO and is implemented
+as a function that can be used in other applications.
 
 See also 16-h2_scan.py, 30-scan_pes.py, 32-break_spin_symm.py
 '''

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -47,60 +47,6 @@ def init_guess_by_minao(mol, breaksym=BREAKSYM):
             dmb[p0:p1,p0:p1] = dma[p0:p1,p0:p1]
     return numpy.array((dma,dmb))
 
-def init_guess_mixed(mol,mixing_parameter=np.pi/4):
-    ''' Generate density matrix with broken spatial and spin symmetry by mixing
-    HOMO and LUMO orbitals following ansatz in Szabo and Ostlund, Sec 3.8.7.
-    
-    psi_1a = np.cos(q)*psi_homo + np.sin(q)*psi_lumo
-    psi_1b = np.cos(q)*psi_homo - np.sin(q)*psi_lumo
-        
-    psi_2a = -np.sin(q)*psi_homo + np.cos(q)*psi_lumo
-    psi_2b =  np.sin(q)*psi_homo + np.cos(q)*psi_lumo
-
-    Returns: 
-        Density matricies, a list of 2D ndarrays for alpha and beta spins
-    '''
-    # opt: q, mixing parameter 0 < q < 2 pi
-    
-    #based on init_guess_by_1e
-    h1e = hf.get_hcore(mol)
-    s1e = hf.get_ovlp(mol)
-    mo_energy, mo_coeff = hf.eig(h1e, s1e)
-    mo_occ = hf.get_occ(mo_energy, mo_coeff)
-
-    homo_idx=0
-    lumo_idx=1
-
-    for i in range(len(mo_occ)-1):
-        if mo_occ[i]>0 and mo_occ[i+1]<0:
-            homo_idx=i
-            lumo_idx=i+1
-
-    psi_homo=mo_coeff[:, homo_idx]
-    psi_lumo=mo_coeff[:, lumo_idx]
-    
-    Ca=np.zeros_like(mo_coeff)
-    Cb=np.zeros_like(mo_coeff)
-
-
-    #mix homo and lumo of alpha and beta coefficents
-    q=mixing_parameter
-
-    for k in range(mo_coeff.shape[0]):
-        if k == homo_idx:
-            Ca[:,k] = np.cos(q)*psi_homo + np.sin(q)*psi_lumo
-            Cb[:,k] = np.cos(q)*psi_homo - np.sin(q)*psi_lumo
-            continue
-        if k==lumo_idx:
-            Ca[:,k] = -np.sin(q)*psi_homo + np.cos(q)*psi_lumo
-            Cb[:,k] =  np.sin(q)*psi_homo + np.cos(q)*psi_lumo
-            continue
-        Ca[:,k]=mo_coeff[:,k]
-        Cb[:,k]=mo_coeff[:,k]
-
-    dm =pyscf.scf.UHF(mol).make_rdm1( (Ca,Cb), (mo_occ,mo_occ) )
-    return dm 
-
 def init_guess_by_1e(mol, breaksym=BREAKSYM):
     return UHF(mol).init_guess_by_1e(mol, breaksym)
 

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -47,6 +47,60 @@ def init_guess_by_minao(mol, breaksym=BREAKSYM):
             dmb[p0:p1,p0:p1] = dma[p0:p1,p0:p1]
     return numpy.array((dma,dmb))
 
+def init_guess_mixed(mol,mixing_parameter=np.pi/4):
+    ''' Generate density matrix with broken spatial and spin symmetry by mixing
+    HOMO and LUMO orbitals following ansatz in Szabo and Ostlund, Sec 3.8.7.
+    
+    psi_1a = np.cos(q)*psi_homo + np.sin(q)*psi_lumo
+    psi_1b = np.cos(q)*psi_homo - np.sin(q)*psi_lumo
+        
+    psi_2a = -np.sin(q)*psi_homo + np.cos(q)*psi_lumo
+    psi_2b =  np.sin(q)*psi_homo + np.cos(q)*psi_lumo
+
+    Returns: 
+        Density matricies, a list of 2D ndarrays for alpha and beta spins
+    '''
+    # opt: q, mixing parameter 0 < q < 2 pi
+    
+    #based on init_guess_by_1e
+    h1e = hf.get_hcore(mol)
+    s1e = hf.get_ovlp(mol)
+    mo_energy, mo_coeff = hf.eig(h1e, s1e)
+    mo_occ = hf.get_occ(mo_energy, mo_coeff)
+
+    homo_idx=0
+    lumo_idx=1
+
+    for i in range(len(mo_occ)-1):
+        if mo_occ[i]>0 and mo_occ[i+1]<0:
+            homo_idx=i
+            lumo_idx=i+1
+
+    psi_homo=mo_coeff[:, homo_idx]
+    psi_lumo=mo_coeff[:, lumo_idx]
+    
+    Ca=np.zeros_like(mo_coeff)
+    Cb=np.zeros_like(mo_coeff)
+
+
+    #mix homo and lumo of alpha and beta coefficents
+    q=mixing_parameter
+
+    for k in range(mo_coeff.shape[0]):
+        if k == homo_idx:
+            Ca[:,k] = np.cos(q)*psi_homo + np.sin(q)*psi_lumo
+            Cb[:,k] = np.cos(q)*psi_homo - np.sin(q)*psi_lumo
+            continue
+        if k==lumo_idx:
+            Ca[:,k] = -np.sin(q)*psi_homo + np.cos(q)*psi_lumo
+            Cb[:,k] =  np.sin(q)*psi_homo + np.cos(q)*psi_lumo
+            continue
+        Ca[:,k]=mo_coeff[:,k]
+        Cb[:,k]=mo_coeff[:,k]
+
+    dm =pyscf.scf.UHF(mol).make_rdm1( (Ca,Cb), (mo_occ,mo_occ) )
+    return dm 
+
 def init_guess_by_1e(mol, breaksym=BREAKSYM):
     return UHF(mol).init_guess_by_1e(mol, breaksym)
 


### PR DESCRIPTION
Symmetry breaking of the UHF and RHF solutions does not occur when using
any of the broken symmetry initial guess schemes in PySCF.  This is because
current methods break symmetry without breaking the spatial density. The
function `init_guess_mixed` mixes the HOMO and LUMO of the guess by core
 to break spatial symmetry of alpha and beta HOMOs following Szabo
chapter 3.  

This has been tested for the stretched hydrogen symmetry breaking problem 
but not beyond this two-electron case. 